### PR TITLE
Restore RELENG checks as a PR Tests workflow

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -1,0 +1,26 @@
+# Run release engineering checks on Pull Requests
+#
+# This restores the coverage of the retired GitLab CI 'validation' stage.
+#
+---
+name: PR Tests
+'on':
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  releng-checks:
+    name: 'RELENG checks'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 3.4'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+          bundler-cache: true
+      - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
+      - name: 'Tags and changelogs'
+        run: |
+          bundle exec rake pkg:compare_latest_tag
+          bundle exec rake pkg:create_tag_changelog


### PR DESCRIPTION
Answers "are there additional PR tests that should be running?" — yes, one set: the retired GitLab CI `validation` stage ran **RELENG checks** (`rake pkg:compare_latest_tag` + `rake pkg:create_tag_changelog`) on every MR, and nothing replaced that when the GLCI bridges were removed in #19, leaving PRs with no tests at all (as seen on #22, where only the triage job ran — that one triggers on `pull_request_target` for project tracking, it isn't a test).

This adds a native `PR Tests` workflow running the same two checks (Ruby 3.4.9, fleet-standard job shape). Both pass on current master — the spec version 1.1.1 matches the latest tag with no significant changes, and the changelog parses.

For comparison, the sibling non-module RPM repos (simp-gpgkeys, simp-rsync-skeleton) have no PR tests either — they may want this same workflow, but that's their call; the old GLCI here proves this repo historically had the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)